### PR TITLE
Implement virtual thread support across multiple services

### DIFF
--- a/service/kotlin/app/src/main/kotlin/io/github/salomax/procureflow/app/catalog/graphql/resolvers/CatalogItemResolver.kt
+++ b/service/kotlin/app/src/main/kotlin/io/github/salomax/procureflow/app/catalog/graphql/resolvers/CatalogItemResolver.kt
@@ -5,8 +5,11 @@ import io.github.salomax.procureflow.app.catalog.domain.CatalogItemCategory
 import io.github.salomax.procureflow.app.catalog.domain.CatalogItemStatus
 import io.github.salomax.procureflow.app.catalog.graphql.dto.CatalogItemInputDTO
 import io.github.salomax.procureflow.app.catalog.service.CatalogItemService
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import jakarta.inject.Singleton
 import jakarta.validation.Validator
+import mu.KotlinLogging
 import java.util.*
 
 /**
@@ -17,11 +20,14 @@ class CatalogItemResolver(
     private val catalogItemService: CatalogItemService,
     private val validator: Validator
 ) {
+    private val logger = KotlinLogging.logger {}
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun searchCatalogItems(query: String): List<CatalogItem> {
         return catalogItemService.search(query)
     }
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun catalogItem(id: String): CatalogItem? {
         return try {
             val uuid = UUID.fromString(id)
@@ -31,6 +37,7 @@ class CatalogItemResolver(
         }
     }
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun saveCatalogItem(input: Map<String, Any?>): CatalogItem {
         // Map GraphQL input to DTO
         val dto = mapToInputDTO(input)

--- a/service/kotlin/app/src/main/kotlin/io/github/salomax/procureflow/app/checkout/graphql/resolvers/CheckoutResolver.kt
+++ b/service/kotlin/app/src/main/kotlin/io/github/salomax/procureflow/app/checkout/graphql/resolvers/CheckoutResolver.kt
@@ -7,6 +7,8 @@ import io.github.salomax.procureflow.app.checkout.graphql.dto.CheckoutInputDTO
 import io.github.salomax.procureflow.app.checkout.graphql.dto.CheckoutItemInputDTO
 import io.github.salomax.procureflow.app.checkout.service.CheckoutLogService
 import io.micronaut.json.tree.JsonNode
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import jakarta.inject.Singleton
 import jakarta.validation.Validator
 
@@ -19,6 +21,7 @@ class CheckoutResolver(
     private val validator: Validator
 ) {
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun checkout(input: Map<String, Any?>): CheckoutLog {
         // Map GraphQL input to DTO
         val dto = mapToInputDTO(input)

--- a/service/kotlin/app/src/main/resources/application.yml
+++ b/service/kotlin/app/src/main/resources/application.yml
@@ -1,8 +1,12 @@
 micronaut:
   application:
     name: procureflow-service
+  executors:
+    blocking:
+      virtual: true
   server:
     port: 8081
+    thread-selection: blocking
     cors:
       enabled: true
       configurations:
@@ -21,6 +25,16 @@ micronaut:
           allow-credentials: true
           max-age: 3600
   security:
+    enabled: true
+    
+  # Micrometer Configuration for Metrics Collection
+  metrics:
+    enabled: true
+    export:
+      prometheus:
+        enabled: true
+        step: PT15S
+  observation:
     enabled: true
 
 # JWT Configuration
@@ -89,16 +103,6 @@ flyway:
       baseline-on-migrate: true
       baseline-version: 0
       table: flyway_schema_history_app
-
-# Micrometer Configuration for Metrics Collection
-  metrics:
-    enabled: true
-    export:
-      prometheus:
-        enabled: true
-        step: PT15S
-  observation:
-    enabled: true
 
 # Management Endpoints Configuration
 endpoints:

--- a/service/kotlin/app/src/main/resources/logback-production.xml
+++ b/service/kotlin/app/src/main/resources/logback-production.xml
@@ -17,6 +17,7 @@
               "environment": "production",
               "version": "${APP_VERSION:-unknown}",
               "instance": "${HOSTNAME:-unknown}",
+              "thread": "%thread",
               "trace_id": "%X{traceId:-}",
               "span_id": "%X{spanId:-}",
               "otel_trace_id": "%X{otel.trace_id:-}",
@@ -38,7 +39,7 @@
         <pattern>service=procureflow-service,environment=production,level=%level,logger=%logger{20}</pattern>
       </label>
       <message>
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
       </message>
     </format>
     <filter class="io.github.salomax.procureflow.logging.MDCFilter" />

--- a/service/kotlin/app/src/main/resources/logback.xml
+++ b/service/kotlin/app/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="io.github.salomax.procureflow.common.logging.MDCFilter" />
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
   
@@ -18,7 +18,7 @@
   </logger>
   
   <!-- Micronaut framework logging -->
-  <logger name="io.micronaut" level="INFO" additivity="false">
+  <logger name="io.micronaut" level="DEBUG" additivity="false">
     <appender-ref ref="STDOUT" />
   </logger>
   

--- a/service/kotlin/assistant/src/main/kotlin/io/github/salomax/procureflow/assistant/graphql/resolvers/AssistantResolver.kt
+++ b/service/kotlin/assistant/src/main/kotlin/io/github/salomax/procureflow/assistant/graphql/resolvers/AssistantResolver.kt
@@ -2,6 +2,8 @@ package io.github.salomax.procureflow.assistant.graphql.resolvers
 
 import io.github.salomax.procureflow.assistant.agent.AssistantAgent
 import io.github.salomax.procureflow.assistant.service.ConversationService
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import jakarta.inject.Singleton
 import kotlinx.coroutines.runBlocking
 
@@ -11,6 +13,7 @@ class AssistantResolver(
     private val conversationService: ConversationService
 ) {
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun chat(input: Map<String, Any?>): ChatResponse {
         val sessionId = extractField<String>(input, "sessionId")
         val message = extractField<String>(input, "message")
@@ -26,6 +29,7 @@ class AssistantResolver(
         }
     }
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun conversation(sessionId: String): Conversation? {
         val context = conversationService.getContext(sessionId) ?: return null
         
@@ -36,6 +40,7 @@ class AssistantResolver(
         )
     }
     
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun clearConversation(sessionId: String): Boolean {
         conversationService.clearContext(sessionId)
         return true

--- a/service/kotlin/assistant/src/main/resources/application.yml
+++ b/service/kotlin/assistant/src/main/resources/application.yml
@@ -1,8 +1,12 @@
 micronaut:
   application:
     name: procureflow-assistant
+  executors:
+    blocking:
+      virtual: true
   server:
     port: 8082
+    thread-selection: blocking
     cors:
       enabled: true
       configurations:

--- a/service/kotlin/assistant/src/main/resources/logback-production.xml
+++ b/service/kotlin/assistant/src/main/resources/logback-production.xml
@@ -17,6 +17,7 @@
               "environment": "production",
               "version": "${APP_VERSION:-unknown}",
               "instance": "${HOSTNAME:-unknown}",
+              "thread": "%thread",
               "trace_id": "%X{traceId:-}",
               "span_id": "%X{spanId:-}",
               "otel_trace_id": "%X{otel.trace_id:-}",
@@ -38,7 +39,7 @@
         <pattern>service=procureflow-service,environment=production,level=%level,logger=%logger{20}</pattern>
       </label>
       <message>
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
       </message>
     </format>
     <filter class="io.github.salomax.procureflow.logging.MDCFilter" />

--- a/service/kotlin/assistant/src/main/resources/logback.xml
+++ b/service/kotlin/assistant/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="io.github.salomax.procureflow.common.logging.MDCFilter" />
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
   

--- a/service/kotlin/common/src/main/kotlin/io/github/salomax/procureflow/common/graphql/GraphQLArgumentUtils.kt
+++ b/service/kotlin/common/src/main/kotlin/io/github/salomax/procureflow/common/graphql/GraphQLArgumentUtils.kt
@@ -105,6 +105,10 @@ object GraphQLArgumentUtils {
     /**
      * Creates a data fetcher with automatic argument validation.
      * This reduces boilerplate by automatically validating required arguments.
+     * 
+     * Note: This data fetcher will run on whatever thread the GraphQL execution is using.
+     * If the controller method has @ExecuteOn(TaskExecutors.BLOCKING), the entire GraphQL
+     * execution (including data fetchers) should run on virtual threads.
      */
     fun <T> createValidatedDataFetcher(
         requiredArgs: List<String> = emptyList(),

--- a/service/kotlin/common/src/main/kotlin/io/github/salomax/procureflow/common/graphql/GraphQLController.kt
+++ b/service/kotlin/common/src/main/kotlin/io/github/salomax/procureflow/common/graphql/GraphQLController.kt
@@ -6,6 +6,8 @@ import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.Post
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
 import graphql.execution.UnknownOperationException
@@ -35,6 +37,8 @@ open class GraphQLControllerBase(private val graphQL: GraphQL) {
    *    using toSpecification(), ensuring the payload is JSON-serializable without extra annotations.
    */
   @Post(consumes = [APPLICATION_JSON], produces = [APPLICATION_JSON])
+  // This is necessary to ensure the execution runs on a virtual thread
+  @ExecuteOn(TaskExecutors.BLOCKING)
   open fun post(
     @Body request: GraphQLRequest,
     @Header("Authorization") authorization: String?

--- a/service/kotlin/security/src/main/kotlin/io/github/salomax/procureflow/security/graphql/SecurityAuthResolver.kt
+++ b/service/kotlin/security/src/main/kotlin/io/github/salomax/procureflow/security/graphql/SecurityAuthResolver.kt
@@ -10,6 +10,8 @@ import io.github.salomax.procureflow.common.graphql.payload.GraphQLPayloadFactor
 import io.github.salomax.procureflow.security.model.UserEntity
 import io.github.salomax.procureflow.security.service.AuthenticationService
 import io.github.salomax.procureflow.security.repo.UserRepository
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import jakarta.inject.Singleton
 import mu.KotlinLogging
 
@@ -34,6 +36,7 @@ class SecurityAuthResolver(
     /**
      * Sign in mutation resolver
      */
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun signIn(input: Map<String, Any?>): GraphQLPayload<SignInPayloadDTO> {
         return try {
             val email = input["email"] as? String ?: throw IllegalArgumentException("Email is required")
@@ -79,6 +82,7 @@ class SecurityAuthResolver(
      * @param token The JWT access token from Authorization header
      * @return UserDTO if token is valid, null otherwise
      */
+    @ExecuteOn(TaskExecutors.BLOCKING)
     fun getCurrentUser(token: String?): UserDTO? {
         if (token == null) {
             logger.debug { "No token provided" }

--- a/service/kotlin/security/src/main/resources/application.yml
+++ b/service/kotlin/security/src/main/resources/application.yml
@@ -1,8 +1,12 @@
 micronaut:
   application:
     name: procureflow-service
+  executors:
+    blocking:
+      virtual: true
   server:
     port: 8080
+    thread-selection: blocking
     cors:
       enabled: true
       configurations:

--- a/service/kotlin/security/src/main/resources/logback-production.xml
+++ b/service/kotlin/security/src/main/resources/logback-production.xml
@@ -17,6 +17,7 @@
               "environment": "production",
               "version": "${APP_VERSION:-unknown}",
               "instance": "${HOSTNAME:-unknown}",
+              "thread": "%thread",
               "trace_id": "%X{traceId:-}",
               "span_id": "%X{spanId:-}",
               "otel_trace_id": "%X{otel.trace_id:-}",
@@ -38,7 +39,7 @@
         <pattern>service=procureflow-service,environment=production,level=%level,logger=%logger{20}</pattern>
       </label>
       <message>
-        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
       </message>
     </format>
     <filter class="io.github.salomax.procureflow.logging.MDCFilter" />

--- a/service/kotlin/security/src/main/resources/logback.xml
+++ b/service/kotlin/security/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="io.github.salomax.procureflow.common.logging.MDCFilter" />
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
   

--- a/spec/SPECIFICATION_MANIFEST.md
+++ b/spec/SPECIFICATION_MANIFEST.md
@@ -42,6 +42,7 @@
 | GraphQL Federation | `service/graphql-federation-architecture.md` | API | graphql, federation, apollo |
 | Database Schema | `service/database-schema-organization.md` | Database | database, schema, organization |
 | JPA Entities | `service/kotlin/jpa-entity.md` | Backend | jpa, entity, kotlin |
+| Virtual Threads | `service/kotlin/virtual-threads.md` | Backend | virtual-threads, java21, performance, concurrency |
 | Testing Guidelines | `service/testing-guidelines.md` | Testing | testing, unit-tests, integration-tests, best-practices |
 
 ### Web Frontend Documentation
@@ -102,6 +103,7 @@ adr/0003-kotlin-micronaut-backend.md
   ├── service/graphql-federation-architecture.md
   ├── service/database-schema-organization.md
   ├── service/kotlin/jpa-entity.md
+  ├── service/kotlin/virtual-threads.md
   └── contracts/graphql-federation.md
 ```
 
@@ -118,7 +120,7 @@ adr/0004-typescript-nextjs-frontend.md
 ## Search Optimization Tags
 
 ### Technology Stack
-- `kotlin`, `micronaut`, `gradle`
+- `kotlin`, `micronaut`, `gradle`, `java21`, `virtual-threads`
 - `typescript`, `react`, `nextjs`
 - `postgresql`, `graphql`, `apollo`
 - `docker`, `kubernetes`, `argo-cd`
@@ -134,6 +136,7 @@ adr/0004-typescript-nextjs-frontend.md
 ### Patterns
 - `dependency-injection`, `repository-pattern`
 - `graphql-resolvers`, `federation-directives`
+- `virtual-threads`, `@ExecuteOn`, `blocking-executor`
 - `server-components`, `client-components`
 - `design-tokens`, `component-system`
 

--- a/spec/service/kotlin/virtual-threads.md
+++ b/spec/service/kotlin/virtual-threads.md
@@ -1,0 +1,318 @@
+---
+id: service-kotlin-virtual-threads
+title: Service — Virtual Threads Configuration (Kotlin + Micronaut + Java 21)
+area: service
+version: 1.0
+tags: [kotlin, micronaut, java21, virtual-threads, performance, concurrency, loom]
+last_reviewed: 2025-01-15
+---
+
+# Virtual Threads Configuration in Kotlin Service
+
+This guide covers the configuration and best practices for using virtual threads in our Kotlin service with Micronaut and Java 21.
+
+## Overview
+
+Virtual threads (Project Loom) were introduced in Java 19 as a preview feature and became stable in Java 21. They provide lightweight, high-throughput concurrency for I/O-bound operations, allowing millions of virtual threads to run on a small number of platform threads.
+
+## Requirements
+
+### Java Version
+- **Minimum**: Java 21 (virtual threads are stable)
+- **JRE**: Must be Java 21 or later (e.g., `eclipse-temurin:21-jre`)
+
+### Micronaut Version
+- **Minimum**: Micronaut 4.0.0+ (virtual thread support)
+- **Recommended**: Micronaut 4.9.0+ (improved virtual thread integration)
+
+## Configuration
+
+### Application Configuration
+
+All services **MUST** include the following configuration in `application.yml`:
+
+```yaml
+micronaut:
+  executors:
+    blocking:
+      type: fixed
+      virtual: true
+  server:
+    thread-selection: blocking
+```
+
+**Key Configuration Points:**
+- `executors.blocking.virtual: true` - Enables virtual threads for the `BLOCKING` executor
+- `executors.blocking.type: fixed` - Uses a fixed thread pool executor type
+- `server.thread-selection: blocking` - Configures server to handle blocking operations appropriately
+
+### Complete Configuration Example
+
+```yaml
+micronaut:
+  application:
+    name: my-service
+  executors:
+    blocking:
+      type: fixed
+      virtual: true
+  server:
+    port: 8080
+    thread-selection: blocking
+    cors:
+      enabled: true
+      # ... other server config
+```
+
+## Annotation Placement
+
+### ✅ REQUIRED: Controllers (Entry Points)
+
+All HTTP controller methods that handle requests **MUST** be annotated with `@ExecuteOn(TaskExecutors.BLOCKING)`:
+
+```kotlin
+@Controller("/graphql")
+class GraphQLController {
+    @Post(consumes = [APPLICATION_JSON], produces = [APPLICATION_JSON])
+    @ExecuteOn(TaskExecutors.BLOCKING)  // ✅ REQUIRED
+    fun post(
+        @Body request: GraphQLRequest,
+        @Header("Authorization") authorization: String?
+    ): Map<String, Any?> {
+        // Controller logic
+    }
+}
+```
+
+**Why**: Ensures the entire request handling runs on virtual threads from the entry point.
+
+### ✅ REQUIRED: GraphQL Resolvers
+
+All GraphQL resolver methods **MUST** be annotated with `@ExecuteOn(TaskExecutors.BLOCKING)`:
+
+```kotlin
+@Singleton
+class ProductResolver(
+    private val productService: ProductService
+) {
+    @ExecuteOn(TaskExecutors.BLOCKING)  // ✅ REQUIRED
+    fun searchProducts(query: String): List<Product> {
+        return productService.search(query)
+    }
+    
+    @ExecuteOn(TaskExecutors.BLOCKING)  // ✅ REQUIRED
+    fun product(id: String): Product? {
+        return productService.get(UUID.fromString(id))
+    }
+    
+    @ExecuteOn(TaskExecutors.BLOCKING)  // ✅ REQUIRED
+    fun saveProduct(input: Map<String, Any?>): Product {
+        // Mutation logic
+    }
+}
+```
+
+**Why**: GraphQL execution may switch threads internally. Resolver annotations ensure virtual threads are used even if GraphQL switches threads.
+
+### ❌ NOT REQUIRED: Service Layer
+
+Service methods **SHOULD NOT** have `@ExecuteOn` annotations:
+
+```kotlin
+@Singleton
+class ProductService(
+    private val repo: ProductRepository
+) {
+    // ❌ NO @ExecuteOn annotation needed
+    fun search(query: String): List<Product> {
+        return repo.findAll().map { it.toDomain() }
+    }
+    
+    // ❌ NO @ExecuteOn annotation needed
+    fun get(id: UUID): Product? {
+        return repo.findById(id).orElse(null)?.toDomain()
+    }
+}
+```
+
+**Why**: 
+- Services inherit virtual thread context from resolvers/controllers
+- Services should remain framework-agnostic
+- Threading is an infrastructure concern, not a business logic concern
+
+## Thread Context Flow
+
+The virtual thread context flows through the call chain:
+
+```
+HTTP Request
+  → Controller [@ExecuteOn] (Virtual Thread A)
+    → GraphQL.execute()
+      → DataFetcher
+        → Resolver [@ExecuteOn] (Virtual Thread A or B)
+          → Service (inherits Virtual Thread)
+            → Repository (inherits Virtual Thread)
+```
+
+## Best Practices
+
+### 1. Annotation Strategy
+
+**✅ DO:**
+- Annotate all controller methods
+- Annotate all resolver methods
+- Keep services annotation-free
+
+**❌ DON'T:**
+- Add annotations to service methods
+- Add annotations to repository methods
+- Mix virtual thread and platform thread executors unnecessarily
+
+### 2. I/O-Bound Operations
+
+Virtual threads are ideal for:
+- ✅ Database operations (JPA/Hibernate)
+- ✅ HTTP client calls
+- ✅ File I/O operations
+- ✅ Network operations
+
+Virtual threads are **NOT** ideal for:
+- ❌ CPU-intensive computations
+- ❌ Long-running calculations
+- ❌ Blocking operations that hold locks
+
+### 3. Logging Thread Information
+
+All logback configurations **MUST** include thread information in the log pattern:
+
+**Development (`logback.xml`):**
+```xml
+<pattern>%d{HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+```
+
+**Production (`logback-production.xml`):**
+```xml
+<!-- JSON encoder -->
+<pattern>
+  <pattern>
+    {
+      "thread": "%thread",
+      "service": "my-service",
+      ...
+    }
+  </pattern>
+</pattern>
+
+<!-- Loki message -->
+<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{correlationId:-}] %-5level %logger{36} - %msg%n</pattern>
+```
+
+**Why**: Enables verification that virtual threads are being used (thread names like `ForkJoinPool-1-worker-1` with `isVirtual: true`).
+
+## Verification
+
+### Checking Virtual Thread Usage
+
+1. **Check Logs**: Look for thread names in logs
+   - Virtual threads: `ForkJoinPool-1-worker-1`, `VirtualThread-*`
+   - Platform threads: `default-nioEventLoopGroup-*-*`, `pool-*-thread-*`
+
+2. **Verify Configuration**: Ensure `application.yml` has the required settings
+
+3. **Test Execution**: Run a request (e.g., GraphQL query, REST endpoint) and check logs for thread information
+
+### Expected Behavior
+
+- ✅ Controller methods run on virtual threads
+- ✅ Resolver methods run on virtual threads
+- ✅ Service methods inherit virtual threads
+- ✅ Database operations run on virtual threads
+
+## Common Issues
+
+### Issue: Still Seeing Platform Threads
+
+**Symptoms**: Logs show `default-nioEventLoopGroup-*-*` threads
+
+**Solutions**:
+1. Verify `application.yml` configuration is correct
+2. Ensure `@ExecuteOn(TaskExecutors.BLOCKING)` is on controllers and resolvers
+3. Restart the application after configuration changes
+4. Verify Java 21 is being used: `java -version`
+
+### Issue: Configuration Not Applied
+
+**Symptoms**: `ExecutorType.virtual` error or configuration not recognized
+
+**Solutions**:
+1. Use `type: fixed` with `virtual: true` (not `type: virtual`)
+2. Ensure Micronaut version is 4.0.0+
+3. Check for typos in `application.yml`
+
+## Migration Guide
+
+### From Platform Threads to Virtual Threads
+
+1. **Update Configuration**: Add virtual thread configuration to `application.yml`
+2. **Add Annotations**: Add `@ExecuteOn(TaskExecutors.BLOCKING)` to controllers and resolvers
+3. **Update Logging**: Add thread information to logback patterns
+4. **Test**: Verify virtual threads are being used
+5. **Monitor**: Check performance and resource usage
+
+## Performance Considerations
+
+### Benefits
+
+- **High Concurrency**: Support millions of concurrent operations
+- **Low Overhead**: Minimal memory footprint per virtual thread
+- **Better Scalability**: Improved throughput for I/O-bound workloads
+- **Simpler Code**: No need for complex async/await patterns
+
+### Limitations
+
+- **CPU-Bound Work**: Not suitable for CPU-intensive operations
+- **Pin Operations**: Some operations may pin virtual threads to platform threads
+- **Thread-Local Storage**: Use with caution (prefer scoped values in Java 21+)
+
+## Dependencies
+
+### Required Dependencies
+
+No additional dependencies are required. Virtual threads are part of Java 21 and Micronaut 4.0.0+.
+
+### Configuration Dependencies
+
+Ensure your build configuration targets Java 21:
+
+```kotlin
+// build.gradle.kts
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+}
+```
+
+## References
+
+- [Micronaut Virtual Threads Documentation](https://docs.micronaut.io/latest/guide/index.html#virtualThreads)
+- [Java Virtual Threads (JEP 444)](https://openjdk.org/jeps/444)
+- [Project Loom](https://openjdk.org/projects/loom/)
+
+## Summary
+
+**Key Rules:**
+1. ✅ Configure `executors.blocking.virtual: true` in `application.yml`
+2. ✅ Add `@ExecuteOn(TaskExecutors.BLOCKING)` to all controller methods
+3. ✅ Add `@ExecuteOn(TaskExecutors.BLOCKING)` to all resolver methods
+4. ❌ Do NOT add annotations to service methods
+5. ✅ Include thread information in logback patterns
+6. ✅ Use Java 21+ for stable virtual thread support
+
+This ensures consistent virtual thread usage across all services and enables optimal performance for I/O-bound operations.
+


### PR DESCRIPTION
Implement virtual thread support across multiple services by adding @ExecuteOn(TaskExecutors.BLOCKING) annotations to GraphQL resolvers and controllers. Update application.yml configurations to enable virtual threads and adjust logging patterns to include thread information. This enhances concurrency handling and performance for I/O-bound operations in the Kotlin service.